### PR TITLE
3.10 lroc lronacpho get default phopar file from calibration dir

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - geotiff==1.4.2
   - gmm==5.0
   - gmp==6.1.2
-  - gsl==2.2.1
+  - gsl==2.6
   - hdf5==1.8.18
   - icu==58.2
   - jama==125

--- a/isis/src/lro/apps/lronacpho/LROCEmpirical.cpp
+++ b/isis/src/lro/apps/lronacpho/LROCEmpirical.cpp
@@ -19,7 +19,7 @@ namespace Isis {
 
  /**
   * Create an LROCEmpirical photometric object
-  *
+  * 
   * @author 2016-08-15 Victor Silva
   *
   * @internal
@@ -41,14 +41,14 @@ namespace Isis {
    * @brief Initialize class from input PVL and Cube files
    *
    * This method is typically called at the class instantiation
-   * time but is reentrant. It reads the parameter PVL file and
+   * time but is reentrant. It reads the parameter PVL file and 
    * extracts Photometric model and Normalization models from it.
    * The cube is needed to match all potential profiles for each
    * band.
    *
    * @param pvl Input PVL parameter files
    * @param cube Input cube file to correct
-   *
+   * 
    * @throws IException::User "Errors in the input PVL file."
    * @throws IException::User "Band with wavelength Center does not have
    *                           PhotometricModel Algorithm group/profile."
@@ -76,6 +76,7 @@ namespace Isis {
     PvlObject::PvlGroupIterator algo = phoObj.beginGroup();
 
     while (algo != phoObj.endGroup()) {
+
       if (algo->name().toLower() == "algorithm") {
         m_profiles.push_back(DbProfile(phoProf, DbProfile(*algo)));
       }
@@ -95,7 +96,7 @@ namespace Isis {
       }
       else { // Appropriate photometric parameters not found
         ostringstream mess;
-        mess << "Band [" << i + 1 << "] with wavelength Center = [" << center[i] <<
+        mess << "Band [" << i + 1 << "] with wavelength Center = [" << center[i] << 
         "] does not have PhotometricModel Algorithm group/profile";
         IException e(IException::User, mess.str(), _FILEINFO_);
         errs += e.toString() + "\n";
@@ -111,18 +112,19 @@ namespace Isis {
     return;
   }
 
+
   /**
    * @brief Method to get photometric property given angles
    *
-   * This method computes photometric property at the given cube location after
+   * This method computes photometric property at the given cube location after 
    * proper parameter container is found for the specific band.
-   *
+   * 
    * @param i    Incidence angle in degrees
    * @param e    Emission angle in degrees
    * @param g    Phase angle in degrees
    * @param band cube band to be tested
    *
-   *
+   * 
    * @throws IException::Programmer "Provided band out of range."
    *
    * @return @b double The photometric property
@@ -144,10 +146,11 @@ namespace Isis {
     return (m_bandpho[band - 1].phoStd / ph);
   }
 
+
   /**
    * @brief Performs actual photometric correction calculations
    *
-   * This routine computes photometric correction using parameters for the
+   * This routine computes photometric correction using parameters for the 
    * LROC Emperical equation.
    *
    * @param parms Container of band-specific exponential parameters
@@ -162,8 +165,7 @@ namespace Isis {
    * @internal
    *   @history 2016-08-15 Victor Silva - Adapted code from lrowacpho application
    *                         written by Kris Becker
-   *   @history 2019-03-26 Victor Silva - Added b parameters for 2019 version of
-   *            LROC Empirical algorithm
+   *
    */
   double LROCEmpirical::photometry( const Parameters &parms, double i, double e, double g ) const {
     //  Ensure problematic values are adjusted
@@ -183,35 +185,25 @@ namespace Isis {
     double mu = cos(e);
     double mu0 = cos(i);
     double alpha = g;
-    double rcal;
-
-    if (parms.algoVersion == 2014 )//|| parms.algoVersion == 0)
-      rcal =  exp(parms.aTerms[0] + parms.aTerms[1] * alpha + parms.aTerms[2] * mu +  parms.aTerms[3] * mu0);
-    else if (parms.algoVersion == 2019)
-      rcal = mu0 / (mu + mu0) * exp(parms.bTerms[0] + parms.bTerms[1] * (alpha * alpha) + parms.bTerms[2] * alpha + parms.bTerms[3] * sqrt(alpha) + parms.bTerms[4] * mu + parms.bTerms[5] * mu0 + parms.bTerms[6] * (mu0 * mu0) );
-    else {
-      std::string mess = "Algorithm version in PVL file not recognized [" + IString(parms.algoVersion) + "]. ";
-      throw IException(IException::Programmer, mess, _FILEINFO_);
-    }
+    double rcal =  exp(parms.a0 + parms.a1 * alpha + parms.a2 * mu +  parms.a3 * mu0);
 
     return (rcal);
   }
 
+
   /**
    * @brief Return parameters used for all bands
-   *
+   * 
    * Method creates keyword vector of band-specific parameters
    * used in the photometric correction.
    *
    * @param pvl Output PVL container for keywords written
    *
-   * @author 2016-08-15 Victor Silva
+   * @author 2016-08-15 Victor Silva 
    *
    * @internal
    *   @history 2016-08-15 Victor Silva - Adapted code from lrowacpho application
    *                         written by Kris Becker
-   *   @history 2019-03-26 Victor Silva - Added b parameters for 2019 version of
-   *            LROC Empirical algorithm
    */
   void LROCEmpirical::report( PvlContainer &pvl ) {
 
@@ -219,18 +211,16 @@ namespace Isis {
     pvl.addComment(" where:");
     pvl.addComment("  mu0 = cos(incidence)");
     pvl.addComment("  mu = cos(emission)");
-
-    if (m_bandpho[0].algoVersion == 2019 || m_bandpho[0].algoVersion == 0 )
-      pvl.addComment("  F(mu, mu0, phase) = mu0 / (mu + mu0) * exp(B0 + B1 * (alpha * alpha) + B2 * alpha + B3 * sqrt(alpha) + B4 * mu + B5 * mu0 + B6 * (mu0 * mu0) )");
-    else if (m_bandpho[0].algoVersion == 2014)
-      pvl.addComment("  F(mu, mu0, phase) = exp (A0 + A1 * phase + A2 * mu + A3 * mu0 ");
-    else {
-      std::string mess = "Could not file the correction algorithm name.";
-      throw IException(IException::Programmer, mess, _FILEINFO_);
-    }
+    pvl.addComment("  F(mu, mu0, phase) = exp(A0 + A1 * phase + A2 * mu + A3 * mu0 ");
 
     pvl += PvlKeyword("Algorithm", "LROC_Empirical");
-    pvl += PvlKeyword("AlgorithmVersion", toString(m_bandpho[0].algoVersion), "" );
+    pvl += PvlKeyword("IncRef", toString(m_iRef), "degrees");
+    pvl += PvlKeyword("EmaRef", toString(m_eRef), "degrees");
+    pvl += PvlKeyword("Algorithm", "LROC_Empirical");
+    pvl += PvlKeyword("IncRef", toString(m_iRef), "degrees");
+    pvl += PvlKeyword("EmaRef", toString(m_eRef), "degrees");
+    pvl += PvlKeyword("EmaRef", toString(m_eRef), "degrees");
+    pvl += PvlKeyword("Algorithm", "LROC_Empirical");
     pvl += PvlKeyword("IncRef", toString(m_iRef), "degrees");
     pvl += PvlKeyword("EmaRef", toString(m_eRef), "degrees");
     pvl += PvlKeyword("PhaRef", toString(m_gRef), "degrees");
@@ -240,25 +230,22 @@ namespace Isis {
     PvlKeyword bbc("BandBinCenter");
     PvlKeyword bbct("BandBinCenterTolerance");
     PvlKeyword bbn("BandNumber");
-
-    std::vector<PvlKeyword> aTermKeywords;
-    std::vector<PvlKeyword> bTermKeywords;
-    for (unsigned int i = 0; i < m_bandpho[0].aTerms.size(); i++)
-        aTermKeywords.push_back(PvlKeyword("A" + toString((int) i)));
-    for (unsigned int i = 0; i < m_bandpho[0].bTerms.size(); i++)
-        bTermKeywords.push_back(PvlKeyword("B" + toString((int) i)));
+    PvlKeyword a0("A0");
+    PvlKeyword a1("A1");
+    PvlKeyword a2("A2");
+    PvlKeyword a3("A3");
 
     for (unsigned int i = 0; i < m_bandpho.size(); i++) {
-        Parameters &p = m_bandpho[i];
-        units.addValue(p.units);
-        phostd.addValue(toString(p.phoStd));
-        bbc.addValue(toString(p.wavelength));
-        bbct.addValue(toString(p.tolerance));
-        bbn.addValue(toString(p.band));
-        for (unsigned int j = 0; j < aTermKeywords.size(); j++)
-          aTermKeywords[j].addValue(toString(p.aTerms[j]));
-        for (unsigned int j = 0; j < bTermKeywords.size(); j++)
-          bTermKeywords[j].addValue(toString(p.bTerms[j]));
+      Parameters &p = m_bandpho[i];
+      units.addValue(p.units);
+      phostd.addValue(toString(p.phoStd));
+      bbc.addValue(toString(p.wavelength));
+      bbct.addValue(toString(p.tolerance));
+      bbn.addValue(toString(p.band));
+      a0.addValue(toString(p.a0));
+      a1.addValue(toString(p.a1));
+      a2.addValue(toString(p.a2));
+      a3.addValue(toString(p.a3));
     }
 
     pvl += units;
@@ -266,11 +253,10 @@ namespace Isis {
     pvl += bbc;
     pvl += bbct;
     pvl += bbn;
-
-    for (unsigned int i = 0; i < aTermKeywords.size(); i++)
-        pvl += aTermKeywords[i];
-    for (unsigned int i = 0; i < bTermKeywords.size(); i++)
-        pvl += bTermKeywords[i];
+    pvl += a0;
+    pvl += a1;
+    pvl += a2;
+    pvl += a3;
 
     return;
   }
@@ -281,11 +267,11 @@ namespace Isis {
    *
    * This method determines the set of LROCEmpirical parameters to
    * use for a given wavelength. It iterates through all band profiles
-   * as read from the PVL file and computes the difference between
-   * wavelength parameter and the BandBinCenter keyword. The absolute
-   * value of this value is check against the BandBinCenterTolerance
-   * parameter and if it is less than or equal to it, a Parameter
-   * container is returned.
+   * as read from the PVL file and computes the difference between 
+   * wavelength parameter and the BandBinCenter keyword. The absolute 
+   * value of this value is checke against the BandBinCenterTolerance 
+   * parameter and if it is less than or equal to it, a Parameter 
+   * container is returned. 
    *
    * @param wavelength The wavelength to find parameters for
    *
@@ -294,8 +280,8 @@ namespace Isis {
    *                                     found for the wavelength then a
    *                                     default parameters object is returned.
    *
-   * @author 2016-08-15 Victor Silva
-   *
+   * @author 2016-08-15 Victor Silva 
+   * 
    * @internal
    *   @history 2016-08-15 Victor Silva - Adapted from the lrowacpho application
    *                           written by Kris Becker.
@@ -339,26 +325,18 @@ namespace Isis {
    *
    * @internal
    *   @history 2016-08-15 Victor Silva - Adapted from the lrowacpho application
-   *            written by Kris Becker.
-   *
-   *   @history 2019-03-26 Victor Silva - Added b parameters for 2019 version of
-   *            LROC Empirical algorithm
-   *
+                              written by Kris Becker.
    */
   LROCEmpirical::Parameters LROCEmpirical::extract( const DbProfile &profile) const {
     Parameters pars;
-
-    for (int i=0; i<4; i++)
-        pars.aTerms.push_back(toDouble(ConfKey(profile, "A" + toString(i), toString(0.0))));
-    for (int i=0; i<7; i++)
-        pars.bTerms.push_back(toDouble(ConfKey(profile, "B" + toString(i), toString(0.0))));
-
+    pars.a1 = toDouble(ConfKey(profile, "A1", toString(0.0)));
+    pars.a2 = toDouble(ConfKey(profile, "A2", toString(0.0)));
+    pars.a3 = toDouble(ConfKey(profile, "A3", toString(0.0)));
     pars.wavelength = toDouble(ConfKey(profile, "BandBinCenter", toString(Null)));
     pars.tolerance = toDouble(ConfKey(profile, "BandBinCenterTolerance", toString(Null)));
     //  Determine equation units - defaults to Radians
     pars.units = ConfKey(profile, "Units", QString("Radians"));
     pars.phaUnit = (pars.units.toLower() == "degrees") ? 1.0 : rpd_c();
-    pars.algoVersion = toInt(ConfKey(profile, "AlgorithmVersion", QString("0")));
 
     return (pars);
   }

--- a/isis/src/lro/apps/lronacpho/LROCEmpirical.h
+++ b/isis/src/lro/apps/lronacpho/LROCEmpirical.h
@@ -27,8 +27,6 @@ namespace Isis {
    *
    * @internal
    *   @history 2016-08-15 - Code adapted from lrowacpho written by Kris Becker
-   *   @history 2019-03-26 Victor Silva - Added b parameters for 2019 version of
-   *            LROC Empirical algorithm
    *
    */
   class LROCEmpirical : public PhotometricFunction {
@@ -44,32 +42,26 @@ namespace Isis {
        * Container for band photometric correction parameters
        *
        * @author 2016-08-15 Victor Silva
-       *
+       * 
        * @internal
        *   @history 2016-08-05 - Code adapted from lrowacpho written by Kris Becker
-       *   @history 2019-03-26 Victor Silva - Added b parameters for 2019 version of
-       *            LROC Empirical algorithm
        */
       struct Parameters {
-        Parameters() : aTerms(), bTerms(),
+        Parameters() : a0(0.0), a1(0.0), a2(0.0), a3(0.0),
                        wavelength(0.0), tolerance(0.0),
                        units("Degrees"), phaUnit(1.0), band(0), phoStd(0.0),
-                       algoVersion(2019),
                        iProfile(-1) { }
         ~Parameters() { }
-        bool IsValid() const {
-          return (iProfile != -1);
-        }
-        std::vector<double> aTerms; //<! a-terms for 2014 algorithm
-        std::vector<double> bTerms; //<! b-terms for 2019 algorithm
-        double wavelength; //<! Wavelength for correction
-        double tolerance; //<! Wavelength Range/Tolerance
-        QString units; //<! Phase units of equation
-        double phaUnit; //<! 1 for degrees, Pi/180 for radians
-        int band; //<! Cube band parameters
-        double phoStd; //<! Computed photometric std.
-        int algoVersion; //<! Algorithm version
-        int iProfile; //<! Profile index of this data
+        bool IsValid() const { return (iProfile != -1);}
+        double a0, a1, a2, a3; //<! Equation parameters
+        double wavelength;     //<! Wavelength for correction
+        double tolerance;      //<! Wavelength Range/Tolerance
+        QString units;         //<! Phase units of equation
+        double phaUnit;        //<! 1 for degrees, Pi/180 for radians
+        int band;              //<! Cube band parameters
+        double phoStd;         //<! Computed photometric std.
+        int iProfile;          //<! Profile index of this data
+
       };
 
       void init(PvlObject &pvl, Cube &cube);

--- a/isis/src/lro/apps/lronacpho/LROCEmpirical.h
+++ b/isis/src/lro/apps/lronacpho/LROCEmpirical.h
@@ -27,6 +27,8 @@ namespace Isis {
    *
    * @internal
    *   @history 2016-08-15 - Code adapted from lrowacpho written by Kris Becker
+   *   @history 2021-03-12 Victor Silva - Added b parameters for 2019 version of
+   *            LROC Empirical algorithm
    *
    */
   class LROCEmpirical : public PhotometricFunction {
@@ -42,26 +44,32 @@ namespace Isis {
        * Container for band photometric correction parameters
        *
        * @author 2016-08-15 Victor Silva
-       * 
+       *
        * @internal
        *   @history 2016-08-05 - Code adapted from lrowacpho written by Kris Becker
+       *   @history 2021-03-12 Victor Silva - Added b parameters for 2019 version of
+       *            LROC Empirical algorithm
        */
       struct Parameters {
-        Parameters() : a0(0.0), a1(0.0), a2(0.0), a3(0.0),
+        Parameters() : aTerms(), bTerms(),
                        wavelength(0.0), tolerance(0.0),
                        units("Degrees"), phaUnit(1.0), band(0), phoStd(0.0),
+                       algoVersion(2019),
                        iProfile(-1) { }
         ~Parameters() { }
-        bool IsValid() const { return (iProfile != -1);}
-        double a0, a1, a2, a3; //<! Equation parameters
-        double wavelength;     //<! Wavelength for correction
-        double tolerance;      //<! Wavelength Range/Tolerance
-        QString units;         //<! Phase units of equation
-        double phaUnit;        //<! 1 for degrees, Pi/180 for radians
-        int band;              //<! Cube band parameters
-        double phoStd;         //<! Computed photometric std.
-        int iProfile;          //<! Profile index of this data
-
+        bool IsValid() const {
+          return (iProfile != -1);
+        }
+        std::vector<double> aTerms; //<! a-terms for 2014 algorithm
+        std::vector<double> bTerms; //<! b-terms for 2019 algorithm
+        double wavelength; //<! Wavelength for correction
+        double tolerance; //<! Wavelength Range/Tolerance
+        QString units; //<! Phase units of equation
+        double phaUnit; //<! 1 for degrees, Pi/180 for radians
+        int band; //<! Cube band parameters
+        double phoStd; //<! Computed photometric std.
+        int algoVersion; //<! Algorithm version
+        int iProfile; //<! Profile index of this data
       };
 
       void init(PvlObject &pvl, Cube &cube);

--- a/isis/src/lro/apps/lronacpho/lronacpho.xml
+++ b/isis/src/lro/apps/lronacpho/lronacpho.xml
@@ -8,24 +8,18 @@
 
   <description>
     <p>
-      <b>LROC Empirical</b> implements a photometric correction
+      <b>LROC Empirical</b> implements a photometric correction  
    </p>
     <PRE>
       I/F = F(mu, mu0,phase)
               where
                   mu0 = cos(incidence)
                   mu = cos(emission)
-                  (2014 version)
-                    F(mu, mu0, phase) = e(A0 + A1 * phase + A2 * mu + A3 * mu0)
-                  (2019 version)
-                    F(mu, mu0, phase) = mu0 / (mu + mu0) * exp(B0 +
-                     B1 * (alpha * alpha) + B2 * alpha +
-                     B3 * sqrt(alpha) + B4 * mu + B5 * mu0 +
-                     B6 * (mu0 * mu0) );
+                  F(mu, mu0, phase) = e(A0 + A1 * phase + A2 * mu + A3 * mu0) 
     </PRE>
     <p>
-      The equation described accounts for scattering dependance on incidence,
-      emission, and phase angles.  Lunar Reflectance approximately follows this function
+      The equation described accounts for scattering dependance on incidence, 
+      emission, and phase angles.  Lunar Reflectance approximately follows this function 
       and has been tested with repeat coverage at different illumination
       geometries. The exponential equation has been derived from over 760,000 NAC
       image tiles. More information can be found at:
@@ -34,11 +28,11 @@
       http://www.hou.usra.edu/meetings/lpsc2014/pdf/2826.pdf
     </p>
     <p>
-      This application provides features that allow LROC NAC image cubes to be
-      photometrically corrected with a properly formatted PVL input file much
-      like that of the ISIS program <i>photomet</i>. This application restricts
-      much of the options available to the more sophisticated <i>photomet</i>
-      application.  Below is an example input parameter file for this
+      This application provides features that allow LROC NAC image cubes to be 
+      photometrically corrected with a properly formatted PVL input file much 
+      like that of the ISIS program <i>photomet</i>. This application restricts 
+      much of the options available to the more sophisticated <i>photomet</i> 
+      application.  Below is an example input parameter file for this 
       application:
     </p>
   <pre>
@@ -58,75 +52,65 @@
           Name = LROC_Empirical
           FilterName = "Broadband"
           BandBinCenter = 600.0
-          A0 = -2.9811422 (2014 version)
-          A1 = -0.0112862 (2014 version)
-          A2 = -0.8084603 (2014 version)
-          A3 = 1.3248888 (2014 version)
-          B0 = -1.479654495
-          B1 = -0.000083528
-          B2 =  0.012964707
-          B3 = -0.237774774
-          B4 =  0.556075496
-          B5 =  0.663671460
-          B6 = -0.439918609
+          A0 = -2.9811422
+          A1 = -0.0112862
+          A2 = -0.8084603
+          A3 = 1.3248888
         EndGroup
       EndObject
   </pre>
     <p>
       The Normalization object is the PhotometricModel evaluated at the given Incref,
-      Emaref and Pharef angles. The value of the Name parameter is ignored here.
-      The Incref, Emaref, and Pharef are the incidence, emission and phase angles
-      to be  used as the photometric standard. It will be used to normalize the photometric
-      correction parameter to these angles. The equation used to create the
+      Emaref and Pharef angles. The value of the Name parameter is ignored here.   
+      The Incref, Emaref, and Pharef are the incidence, emission and phase angles 
+      to be  used as the photometric standard. It will be used to normalize the photometric 
+      correction parameter to these angles. The equation used to create the 
       photometrically corrected I/F dn is:
     </p>
       <pre>
           odn = idn * (phostd  / ph)
-
-              where phostd is the photometry model evaluated at the given Incref,
-              Emaref and Pharef angles. ph is the photometric correction for the
+         
+              where phostd is the photometry model evaluated at the given Incref, 
+              Emaref and Pharef angles. ph is the photometric correction for the 
               incidence, emission and phase at each pixel
       </pre>
   <p>
-      The "Center" parameter in the above equality comes from the Center keyword
-      in the BandBin group of the input cube file specified in the FROM
-      parameter.  This keyword must exist in the input cube or an error is
-      generated and the program aborts.   BandBinCenter and
-      BandBinCenterTolerance are contained in each Algorithm group.  Only
-      BandBinCenter is required.  If BandBinCenterTolerance is not present in an
-      Algorithm group a value of 1.0E-6 is used.  All input bands in the FROM
-      file must be matched to at least one of the Algorithm parameters otherwise
+      The "Center" parameter in the above equality comes from the Center keyword 
+      in the BandBin group of the input cube file specified in the FROM 
+      parameter.  This keyword must exist in the input cube or an error is 
+      generated and the program aborts.   BandBinCenter and 
+      BandBinCenterTolerance are contained in each Algorithm group.  Only 
+      BandBinCenter is required.  If BandBinCenterTolerance is not present in an 
+      Algorithm group a value of 1.0E-6 is used.  All input bands in the FROM 
+      file must be matched to at least one of the Algorithm parameters otherwise 
       an error is generated and the application is aborted.
     </p>
     <p>
-      The parameter Units is provided to specify if the phase angle is in
-      units of degrees or radians.  It does not have to exist in any group or
-      even in the top Object section.  If it does not exist, "Radians" is the
+      The parameter Units is provided to specify if the phase angle is in 
+      units of degrees or radians.  It does not have to exist in any group or 
+      even in the top Object section.  If it does not exist, "Radians" is the 
       default.
     </p>
     <p>
-      An additional feature of the PVL structure is that any keyword that exists
-      in the Object section of the PhotometricModel Object is propagated to each
-      Algorithm group when it  is read in unless the keyword already exists in
-      the Algorithm group.  If a keyword exists in both the PhotometricModel
-      object and an Algorithm group, the keyword in the Algorithm group has
+      An additional feature of the PVL structure is that any keyword that exists 
+      in the Object section of the PhotometricModel Object is propagated to each 
+      Algorithm group when it  is read in unless the keyword already exists in 
+      the Algorithm group.  If a keyword exists in both the PhotometricModel 
+      object and an Algorithm group, the keyword in the Algorithm group has 
       precedence.
     </p>
     <p>
-      Additional consequences of the photometric correction processing is any
-      incidence angle greater than 90 degrees is set to the ISIS special Null
-      pixel value.  And, of course, any ISIS special pixel encountered on input
+      Additional consequences of the photometric correction processing is any 
+      incidence angle greater than 90 degrees is set to the ISIS special Null 
+      pixel value.  And, of course, any ISIS special pixel encountered on input 
       is propagated to the output TO file without modification.
+     <b>Function is only valid for phase angles between 15 and 65 degrees.</b>
     </p>
   </description>
 
   <history>
     <change name="Victor Silva" date="2016-08-18">
       Version adapted from Kris Becker's LROWACPHO application from 2010
-    </change>
-    <change name="Victor Silva" date="2019-01-15">
-      Included ability to run with default pvl values
-      Added new values for 2019 version of LROC Empirical function
     </change>
   </history>
 
@@ -158,11 +142,11 @@
           Output cube
         </brief>
         <description>
-          This file will contain the photometrically corrected image data after
+          This file will contain the photometrically corrected image data after 
           being corrected by with LROC_Empirical algorithm.
         </description>
       </parameter>
-
+      
       <parameter name="BACKPLANE">
         <type>cube</type>
         <pixelType>real</pixelType>
@@ -182,19 +166,18 @@
       <parameter name="PHOPAR">
         <type>filename</type>
         <fileMode>input</fileMode>
-        <default><item>LROC_Empirical.pvl</item></default>
         <brief>
           PVL file
         </brief>
         <description>
-          This file will contain the parameters A0-A3 to use when
-          applying the LROC Empirical photometric correction.  See the main program
+          This file will contain the parameters A0-A3 to use when 
+          applying the LROC Empirical photometric correction.  See the main program 
           documentation for a full description.
         </description>
          <filter>*.pvl</filter>
       </parameter>
     </group>
-
+    
     <group name="Photometry">
       <parameter name="MINPHASE">
         <type>double</type>
@@ -234,7 +217,7 @@
         <lessThanOrEqual><item>MAXEMISSION</item></lessThanOrEqual>
       </parameter>
       <parameter name="MAXEMISSION">
-        <default><item>85.0</item></default>
+        <default><item>90.0</item></default>
         <type>double</type>
         <brief>Maximum emission angle to trim</brief>
         <description>
@@ -260,7 +243,7 @@
       </parameter>
       <parameter name="MAXINCIDENCE">
         <type>double</type>
-        <default><item>85.0</item></default>
+        <default><item>90.0</item></default>
         <brief>Maximum incidence angle to trim</brief>
         <description>
           Pixels which have a incidence angle greater than this value will be
@@ -271,7 +254,7 @@
         <greaterThanOrEqual><item>MININCIDENCE</item></greaterThanOrEqual>
       </parameter>
     </group>
-
+    
     <group name="Other Options">
       <parameter name="USEDEM">
         <type>boolean</type>
@@ -286,6 +269,6 @@
         </description>
       </parameter>
     </group>
-
+    
   </groups>
 </application>

--- a/isis/src/lro/apps/lronacpho/lronacpho.xml
+++ b/isis/src/lro/apps/lronacpho/lronacpho.xml
@@ -8,18 +8,24 @@
 
   <description>
     <p>
-      <b>LROC Empirical</b> implements a photometric correction  
+      <b>LROC Empirical</b> implements a photometric correction
    </p>
     <PRE>
       I/F = F(mu, mu0,phase)
               where
                   mu0 = cos(incidence)
                   mu = cos(emission)
-                  F(mu, mu0, phase) = e(A0 + A1 * phase + A2 * mu + A3 * mu0) 
+                  (2014 version)
+                    F(mu, mu0, phase) = e(A0 + A1 * phase + A2 * mu + A3 * mu0)
+                  (2019 version)
+                    F(mu, mu0, phase) = mu0 / (mu + mu0) * exp(B0 +
+                     B1 * (alpha * alpha) + B2 * alpha +
+                     B3 * sqrt(alpha) + B4 * mu + B5 * mu0 +
+                     B6 * (mu0 * mu0) );
     </PRE>
     <p>
-      The equation described accounts for scattering dependance on incidence, 
-      emission, and phase angles.  Lunar Reflectance approximately follows this function 
+      The equation described accounts for scattering dependance on incidence,
+      emission, and phase angles.  Lunar Reflectance approximately follows this function
       and has been tested with repeat coverage at different illumination
       geometries. The exponential equation has been derived from over 760,000 NAC
       image tiles. More information can be found at:
@@ -28,11 +34,11 @@
       http://www.hou.usra.edu/meetings/lpsc2014/pdf/2826.pdf
     </p>
     <p>
-      This application provides features that allow LROC NAC image cubes to be 
-      photometrically corrected with a properly formatted PVL input file much 
-      like that of the ISIS program <i>photomet</i>. This application restricts 
-      much of the options available to the more sophisticated <i>photomet</i> 
-      application.  Below is an example input parameter file for this 
+      This application provides features that allow LROC NAC image cubes to be
+      photometrically corrected with a properly formatted PVL input file much
+      like that of the ISIS program <i>photomet</i>. This application restricts
+      much of the options available to the more sophisticated <i>photomet</i>
+      application.  Below is an example input parameter file for this
       application:
     </p>
   <pre>
@@ -52,65 +58,75 @@
           Name = LROC_Empirical
           FilterName = "Broadband"
           BandBinCenter = 600.0
-          A0 = -2.9811422
-          A1 = -0.0112862
-          A2 = -0.8084603
-          A3 = 1.3248888
+          A0 = -2.9811422 (2014 version)
+          A1 = -0.0112862 (2014 version)
+          A2 = -0.8084603 (2014 version)
+          A3 = 1.3248888 (2014 version)
+          B0 = -1.479654495
+          B1 = -0.000083528
+          B2 =  0.012964707
+          B3 = -0.237774774
+          B4 =  0.556075496
+          B5 =  0.663671460
+          B6 = -0.439918609
         EndGroup
       EndObject
   </pre>
     <p>
       The Normalization object is the PhotometricModel evaluated at the given Incref,
-      Emaref and Pharef angles. The value of the Name parameter is ignored here.   
-      The Incref, Emaref, and Pharef are the incidence, emission and phase angles 
-      to be  used as the photometric standard. It will be used to normalize the photometric 
-      correction parameter to these angles. The equation used to create the 
+      Emaref and Pharef angles. The value of the Name parameter is ignored here.
+      The Incref, Emaref, and Pharef are the incidence, emission and phase angles
+      to be  used as the photometric standard. It will be used to normalize the photometric
+      correction parameter to these angles. The equation used to create the
       photometrically corrected I/F dn is:
     </p>
       <pre>
           odn = idn * (phostd  / ph)
-         
-              where phostd is the photometry model evaluated at the given Incref, 
-              Emaref and Pharef angles. ph is the photometric correction for the 
+
+              where phostd is the photometry model evaluated at the given Incref,
+              Emaref and Pharef angles. ph is the photometric correction for the
               incidence, emission and phase at each pixel
       </pre>
   <p>
-      The "Center" parameter in the above equality comes from the Center keyword 
-      in the BandBin group of the input cube file specified in the FROM 
-      parameter.  This keyword must exist in the input cube or an error is 
-      generated and the program aborts.   BandBinCenter and 
-      BandBinCenterTolerance are contained in each Algorithm group.  Only 
-      BandBinCenter is required.  If BandBinCenterTolerance is not present in an 
-      Algorithm group a value of 1.0E-6 is used.  All input bands in the FROM 
-      file must be matched to at least one of the Algorithm parameters otherwise 
+      The "Center" parameter in the above equality comes from the Center keyword
+      in the BandBin group of the input cube file specified in the FROM
+      parameter.  This keyword must exist in the input cube or an error is
+      generated and the program aborts.   BandBinCenter and
+      BandBinCenterTolerance are contained in each Algorithm group.  Only
+      BandBinCenter is required.  If BandBinCenterTolerance is not present in an
+      Algorithm group a value of 1.0E-6 is used.  All input bands in the FROM
+      file must be matched to at least one of the Algorithm parameters otherwise
       an error is generated and the application is aborted.
     </p>
     <p>
-      The parameter Units is provided to specify if the phase angle is in 
-      units of degrees or radians.  It does not have to exist in any group or 
-      even in the top Object section.  If it does not exist, "Radians" is the 
+      The parameter Units is provided to specify if the phase angle is in
+      units of degrees or radians.  It does not have to exist in any group or
+      even in the top Object section.  If it does not exist, "Radians" is the
       default.
     </p>
     <p>
-      An additional feature of the PVL structure is that any keyword that exists 
-      in the Object section of the PhotometricModel Object is propagated to each 
-      Algorithm group when it  is read in unless the keyword already exists in 
-      the Algorithm group.  If a keyword exists in both the PhotometricModel 
-      object and an Algorithm group, the keyword in the Algorithm group has 
+      An additional feature of the PVL structure is that any keyword that exists
+      in the Object section of the PhotometricModel Object is propagated to each
+      Algorithm group when it  is read in unless the keyword already exists in
+      the Algorithm group.  If a keyword exists in both the PhotometricModel
+      object and an Algorithm group, the keyword in the Algorithm group has
       precedence.
     </p>
     <p>
-      Additional consequences of the photometric correction processing is any 
-      incidence angle greater than 90 degrees is set to the ISIS special Null 
-      pixel value.  And, of course, any ISIS special pixel encountered on input 
+      Additional consequences of the photometric correction processing is any
+      incidence angle greater than 90 degrees is set to the ISIS special Null
+      pixel value.  And, of course, any ISIS special pixel encountered on input
       is propagated to the output TO file without modification.
-     <b>Function is only valid for phase angles between 15 and 65 degrees.</b>
     </p>
   </description>
 
   <history>
     <change name="Victor Silva" date="2016-08-18">
       Version adapted from Kris Becker's LROWACPHO application from 2010
+    </change>
+    <change name="Victor Silva" date="2021-03-12">
+      Included ability to run with default pvl values
+      Added new values for 2019 version of LROC Empirical function
     </change>
   </history>
 
@@ -142,11 +158,11 @@
           Output cube
         </brief>
         <description>
-          This file will contain the photometrically corrected image data after 
+          This file will contain the photometrically corrected image data after
           being corrected by with LROC_Empirical algorithm.
         </description>
       </parameter>
-      
+
       <parameter name="BACKPLANE">
         <type>cube</type>
         <pixelType>real</pixelType>
@@ -166,18 +182,19 @@
       <parameter name="PHOPAR">
         <type>filename</type>
         <fileMode>input</fileMode>
+        <default><item>default</item></default>
         <brief>
           PVL file
         </brief>
         <description>
-          This file will contain the parameters A0-A3 to use when 
-          applying the LROC Empirical photometric correction.  See the main program 
+          This file will contain a set of parameters A or B to use when
+          applying the LROC Empirical photometric correction.  See the main program
           documentation for a full description.
         </description>
          <filter>*.pvl</filter>
       </parameter>
     </group>
-    
+
     <group name="Photometry">
       <parameter name="MINPHASE">
         <type>double</type>
@@ -217,7 +234,7 @@
         <lessThanOrEqual><item>MAXEMISSION</item></lessThanOrEqual>
       </parameter>
       <parameter name="MAXEMISSION">
-        <default><item>90.0</item></default>
+        <default><item>85.0</item></default>
         <type>double</type>
         <brief>Maximum emission angle to trim</brief>
         <description>
@@ -243,7 +260,7 @@
       </parameter>
       <parameter name="MAXINCIDENCE">
         <type>double</type>
-        <default><item>90.0</item></default>
+        <default><item>85.0</item></default>
         <brief>Maximum incidence angle to trim</brief>
         <description>
           Pixels which have a incidence angle greater than this value will be
@@ -254,7 +271,7 @@
         <greaterThanOrEqual><item>MININCIDENCE</item></greaterThanOrEqual>
       </parameter>
     </group>
-    
+
     <group name="Other Options">
       <parameter name="USEDEM">
         <type>boolean</type>
@@ -269,6 +286,6 @@
         </description>
       </parameter>
     </group>
-    
+
   </groups>
 </application>

--- a/isis/src/lro/apps/lronacpho/main.cpp
+++ b/isis/src/lro/apps/lronacpho/main.cpp
@@ -1,6 +1,8 @@
 #include "Isis.h"
 
-#include <string>
+#include <QDir>
+#include <QRegExp>
+#include <QString>
 
 #include "Cube.h"
 #include "IException.h"
@@ -9,7 +11,7 @@
 #include "ProcessByLine.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
-
+#include "SpecialPixel.h"
 
 using namespace std;
 using namespace Isis;
@@ -19,21 +21,24 @@ static bool g_useDEM;
 
 void phoCal (Buffer &in, Buffer &out);
 void phoCalWithBackplane (std::vector<Isis::Buffer *> &in, std::vector<Isis::Buffer *> &out );
+void GetCalibrationDirectory(QString calibrationType, QString &calibrationDirectory);
+
 /**
  *
  * @brief Photometric application for the LRO NAC cameras
  *
- * This application provides featurs that allow multiband cubes for LRO NAC cameras 
+ * This application provides features that allow multiband cubes for LRO NAC cameras
  *   to be photometrically corrected
- *   
- * @author 2016-09-16 Victor Silva   
- *      
+ *
+ * @author 2016-09-16 Victor Silva
+ *
  * @internal
- *   @history 2016-09-19 Victor silva - Adapted from lrowacpho written by Kris Becker
- * 
+ *   @history 2016-09-19 Victor Silva - Adapted from lrowacpho written by Kris Becker
+ *	 @history 2021-03-12 Victor Silva - Updates include ability to run with default values
+ * 																			Added new values for 2019 version of LROC Empirical function.
  */
 void IsisMain (){
-  // Isis Processing by line
+  // Isis Processing by brick
   ProcessByLine p;
   // Set up input cube and get camera info
   Cube *iCube = p.SetInputCube("FROM");
@@ -75,18 +80,44 @@ void IsisMain (){
     useBackplane = true;
   }
 
-  // Get parameters file
-  Pvl params(ui.GetFileName("PHOPAR"));
-  IString algoName =   PhotometricFunction::algorithmName(params);
-  algoName.UpCase();
+  // Get name of parameters file
+  QString calDir = "";
+  QString algoName = "";
+  QString algoFile = ui.GetAsString("PHOPAR");
+  qDebug() << "the algo file is: ";
+  qDebug() << algoFile ;
+  if(algoFile.toLower() == "default" || algoFile.length() == 0){
+    GetCalibrationDirectory("", calDir);
+    algoFile = calDir + "NAC_PHO_LROC_Empirical.????.pvl";
+    qDebug() << "made it in here!!!!" ;
+    //cout << algoFile.toStdString() << endl;
+  }
 
-  // Use generic NAC algorithm
+  FileName algoFileName(algoFile);
+
+  if(algoFileName.isVersioned())
+    algoFileName = algoFileName.highestVersion();
+
+  if(!algoFileName.fileExists()) {
+    QString msg = algoFile + " does not exist.";
+    throw IException(IException::User, msg, _FILEINFO_);
+  }
+
+  Pvl params(algoFileName.expanded());
+
+
+
+  algoName = PhotometricFunction::algorithmName(params);
+  algoName = algoName.toUpper();
+
+  // Set NAC algorithm
   if (algoName == "LROC_EMPIRICAL") {
-    g_pho = new LROCEmpirical(params, *iCube, !useBackplane);
+      g_pho = new LROCEmpirical(params, *iCube, !useBackplane);
   }
   else {
-    string msg = " Algorithm Name [" + algoName + "] not recognized. ";
-    msg += "Compatible Algorithms are:\n LROC_Empirical";
+    QString msg = " Algorithm Name [" + algoName + "] not recognized. ";
+    msg += "Compatible Algorithms are:\n LROC_Empirical\n";
+    qDebug() << algoName;
     throw IException(IException::User, msg, _FILEINFO_);
   }
 
@@ -101,13 +132,14 @@ void IsisMain (){
   // Set use of DEM to calculate photometric angles
   g_useDEM = ui.GetBoolean("USEDEM");
 
-   // Begin processing by line
+  // Begin processing by line
   if(useBackplane) {
     p.StartProcess(phoCalWithBackplane);
   }
   else {
     p.StartProcess(phoCal);
   }
+
   // Start all the PVL
   PvlGroup photo("Photometry");
   g_pho->report(photo);
@@ -117,35 +149,6 @@ void IsisMain (){
   delete g_pho;
 }//end IsisMain
 
-/**
- * @brief Apply LROC Empirical photometric correction
- *
- * Process function dispatched for each line to apply the LROC Empirical photometric
- * correction function.
- *
- * @author 2016-09-19 Victor Silva
- *
- * @internal
- *   @history 2016-09-19 Victor silva - Adapted from lrowacpho written by Kris Becker
- *
- * @param in Buffer containing input data
- * @param out Buffer of photometrically corrected data
- */
-void phoCal(Buffer &in, Buffer &out){
-  // Iterate through pixels
-  for(int i = 0; i < in.size(); i++){
-    // Ignore special pixels
-    if(IsSpecial(in[i])){
-      out[i] = in[i];
-    }
-    else{
-      // Get correction and test for validity
-      double ph = g_pho->compute(in.Line(i), in.Sample(i), in.Band(i), g_useDEM);
-      out[i] = ( IsSpecial(ph) ? Null : (in[i] * ph) );
-    }
-  }
-  return;
-}//end phoCal
 
 /**
  * @brief Apply LROC Empirical photometric correction with backplane
@@ -161,24 +164,74 @@ void phoCal(Buffer &in, Buffer &out){
  * @param in Buffer containing input data
  * @param out Buffer of photometrically corrected data
  */
-void phoCalWithBackplane ( std::vector<Isis::Buffer *> &in, std::vector<Isis::Buffer *> &out ) {
+ void phoCal(Buffer &in, Buffer &out){
+   // Iterate through pixels
+   for(int i = 0; i < in.size(); i++){
+     // Ignore special pixels
+     if(IsSpecial(in[i])){
+       out[i] = in[i];
+     }
+     else{
+       // Get correction and test for validity
+       double ph = g_pho->compute(in.Line(i), in.Sample(i), in.Band(i), g_useDEM);
+       out[i] = ( IsSpecial(ph) ? Null : (in[i] * ph) );
+     }
+   }
+   return;
+ }//end phoCal
 
-  Buffer &image = *in[0];
-  Buffer &phase = *in[1];
-  Buffer &emission = *in[2];
-  Buffer &incidence = *in[3];
-  Buffer &calibrated = *out[0];
+ /**
+  * @brief Apply LROC Empirical photometric correction with backplane
+  *
+  * Short function dispatched for each line to apply the LROC Empirical photometrc
+  * correction function.
+  *
+  * @author 2016-09-19 Victor Silva
+  *
+  * @internal
+  *   @history 2016-09-19 Victor silva - Adapted from lrowacpho written by Kris Becker
+  *
+  * @param in Buffer containing input data
+  * @param out Buffer of photometrically corrected data
+  */
+ void phoCalWithBackplane ( std::vector<Isis::Buffer *> &in, std::vector<Isis::Buffer *> &out ) {
 
-  for (int i = 0; i < image.size(); i++) {
-    //  Don't correct special pixels
-    if (IsSpecial(image[i])) {
-      calibrated[i] = image[i];
-    }
-    else {
-    // Get correction and test for validity
-      double ph = g_pho->photometry(incidence[i], emission[i], phase[i], image.Band(i));
-      calibrated[i] = (IsSpecial(ph) ? Null : image[i] * ph);
-    }
-  }
-  return;
-}
+   Buffer &image = *in[0];
+   Buffer &phase = *in[1];
+   Buffer &emission = *in[2];
+   Buffer &incidence = *in[3];
+   Buffer &calibrated = *out[0];
+
+   for (int i = 0; i < image.size(); i++) {
+     //  Don't correct special pixels
+     if (IsSpecial(image[i])) {
+       calibrated[i] = image[i];
+     }
+     else {
+     // Get correction and test for validity
+       double ph = g_pho->photometry(incidence[i], emission[i], phase[i], image.Band(i));
+       calibrated[i] = (IsSpecial(ph) ? Null : image[i] * ph);
+     }
+   }
+   return;
+ }
+
+
+ /**
+  * This method returns an QString containing the path of an
+  * LRO calibration directory
+  *
+  * @param calibrationType
+  * @param calibrationDirectory Path of the calibration directory
+  *
+  * @internal
+  *   @history 2021-03-12 Victor Silva - Added option for base calibration directory
+  */
+ void GetCalibrationDirectory(QString calibrationType, QString &calibrationDirectory) {
+   PvlGroup &dataDir = Preference::Preferences().findGroup("DataDirectory");
+   QString missionDir = (QString) dataDir["LRO"];
+   if(calibrationType != "")
+     calibrationType += "/";
+
+   calibrationDirectory = missionDir + "/calibration/" + calibrationType;
+ }


### PR DESCRIPTION
Updated to get default photometry parameters file from calibration directory and updated to correctly display pvl values.
