### PR TITLE
Revert "Add radiance units label in lrowaccal output cube"

### DIFF
--- a/isis/src/lro/apps/lrowaccal/main.cpp
+++ b/isis/src/lro/apps/lrowaccal/main.cpp
@@ -336,7 +336,7 @@ void IsisMain () {
         vals.addValue(toString(g_iofResponsivity[i]));
     }
     else {
-      calgrp += PvlKeyword("RadiometricType", "AbsoluteRadiance", "W/m2/sr/um");
+      calgrp += PvlKeyword("RadiometricType", "AbsoluteRadiance");
       for (unsigned int i=0; i< g_radianceResponsivity.size(); i++)
         vals.addValue(toString(g_radianceResponsivity[i]));
     }


### PR DESCRIPTION
Reverts lrocdev/ISIS3#18.

I jumped the gun on this one. We still need the GTests added. Should be an easy one to make though. 